### PR TITLE
Update to v0.10.1

### DIFF
--- a/io.github.schwarzen.colormydesktop.yaml
+++ b/io.github.schwarzen.colormydesktop.yaml
@@ -39,5 +39,5 @@ modules:
     sources:
        - type: git
          url: https://github.com/Schwarzen/colormydesktop
-         tag: v0.10
-         commit: e08f3d0a37eb675ff1f65ce1955ec86ee544eebc
+         tag: v0.10.1
+         commit: 329cd949c912ae8e86db89343b2a3d371f9ca920


### PR DESCRIPTION
Fixes naming mismatch in non flatpak installs
Fixes issue where python process would not close properly Updates vesktop CSS targets to be more persistent